### PR TITLE
Traduz 1.1.1 Expressions

### DIFF
--- a/01/1.1.1.md
+++ b/01/1.1.1.md
@@ -94,4 +94,4 @@ Mesmo com expressões complexas, o interpretador sempre opera no mesmo ciclo bá
 
 -----
 
-<a name="footnote-link-1"></a> [1] O JavaScript obedece à convenção de que cada instrução tem um valor (consulte o exercício [4.8](4.1.2#ex-4.8)). Essa convenção, junto com a reputação dos programadores JavaScript de não se preocuparem com a eficiência, nos leva a parafrasear uma piada sobre os programadores Lisp de Alan Perlis (que estava parafraseando Oscar Wilde): Os programadores JavaScript sabem o valor de tudo, mas o custo de nada.
+<a name="footnote-link-1"></a> [1] O JavaScript obedece à convenção de que cada instrução tem um valor (consulte o exercício [4.8](4.1.2#ex-4.8)). Essa convenção, junto com a reputação dos programadores JavaScript de não se preocuparem com a eficiência, nos leva a parafrasear uma piada sobre os programadores Lisp de Alan Perlis (que estava parafraseando Oscar Wilde): *Os programadores JavaScript sabem o valor de tudo, mas o custo de nada.*


### PR DESCRIPTION
Traduzido.

Com dois "poréns":
- No livro original, tem como clicar num bloco de código JavaScript que uma "IDE" aparece e a expressão é avaliada. Não temos isso por padrão no Markdown. Não sei como qual código JavaScript necessário nem como o adicionaríamos ao arquivo um Markdown.
- Há um link para 4.8, que ainda não foi traduzido, ou seja, não existe no repositório. Talvez adicionar um TODO ao #16 ?