### PR TITLE
doc: Traduz 1.1.2 Naming and the Environment (#17)

### DIFF
--- a/01/1.1.2.md
+++ b/01/1.1.2.md
@@ -1,0 +1,65 @@
+# 1.1.2  Nomenclatura e o Ambiente
+
+Um aspecto crítico de uma linguagem de programação são os meios que ela fornece para o uso de nomes para se referir a objetos computacionais, e nosso primeiro desses meios são *constantes*. Dizemos que o nome identifica uma constante cujo *valor* é o objeto.
+
+Em JavaScript, nomeamos constantes com *declarações de constantes*.
+
+```js
+const size = 2;
+```
+
+faz com que o intepretador associe o valor 2 ao tamanho do nome.<sup>[1](#footnote-link-1)</sup> Depois que o nome `size` foi associado ao número 2, podemos nos referir ao valor 2 pelo nome:
+
+```js
+size; 
+```
+2
+
+```js
+5 * size; 
+```
+10
+
+O interpretador JavaScript precisa executar a declaração constante `size` antes que o nome `size` possa ser usado em uma expressão. Neste livro online, as instruções que precisam ser avaliadas antes de uma nova instrução são omitidas por questões de brevidade. Porém, para ver e brincar com o programa, você pode clicar nele. O programa então aparece em uma nova aba do navegador, com a opção "Show Dependencies" (Mostrar Dependências). Assim, como resultado de clicar em
+
+```js
+5 * size; 
+```
+
+uma nova aba aparece contendo o programa e, após clicar em "Show Dependencies", você verá:
+
+```js
+const size = 2;
+5 * size; 
+```
+
+Aqui estão outros exemplos do uso de `const`:
+
+```js
+const pi = 3.14159; 
+```
+```js
+const radius = 10; 
+```
+```js
+pi * radius * radius; 
+```
+314.159
+
+```js
+const circumference = 2 * pi * radius; 
+```
+```js
+circumference; 
+```
+62.8318
+
+A declaração de constantes é o meio mais simples de abstração em nossa linguagem, pois nos permite usar nomes simples para se referir aos resultados de operações compostas, como a `circumference` (circunferência) calculada acima. Em geral, objetos computacionais podem ter estruturas muito complexas e seria extremamente inconveniente ter que lembrar e repetir seus detalhes cada vez que quisermos usá-los. De fato, programas complexos são construídos construindo, passo a passo, objetos computacionais de complexidade crescente. O interpretador torna a construção do programa passo a passo particularmente conveniente porque as associações nome-objeto podem ser criadas de forma incremental em interações sucessivas. Esse recurso incentiva o desenvolvimento e teste incrementais de programas e é amplamente responsável pelo fato de um programa JavaScript geralmente consistir em um grande número de funções relativamente simples.
+
+Deve estar claro que a possibilidade de associar valores a nomes e posteriormente recuperá-los significa que o interpretador deve manter algum tipo de memória que monitore os pares nome-objeto. Essa memória é chamada de *ambiente* (mais precisamente o *ambiente do programa*, já que veremos mais tarde que uma computação pode envolver vários ambientes diferentes).<sup>[2](#footnote-link-2)</sup>
+
+----
+
+<a name="footnote-link-1"></a> [1] Neste livro, não mostramos a resposta do interpretador para avaliar programas que terminam com declarações, uma vez que isso pode depender de instruções anteriores. Consulte o exercício [4.8](4.1.2#ex-4.8) para obter detalhes.
+
+<a name="footnote-link-2"></a> [2] O Capítulo 3 mostrará que essa noção de ambiente é crucial para entender como o interpretador funciona. O Capítulo 4 usará ambientes para implementar interpretadores.


### PR DESCRIPTION
Traduzido.

Tem os mesmos "poréns" do #39:

- No livro original, tem como clicar num bloco de código JavaScript que uma "IDE" aparece e a expressão é avaliada. Não temos isso por padrão no Markdown. Não sei como qual código JavaScript necessário nem como o adicionaríamos ao arquivo um Markdown.
- Há um link para 4.8, que ainda não foi traduzido, ou seja, não existe no repositório. Talvez adicionar um TODO ao #17 ?