### PR TITLE
fix: Remove cache configurations from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
 
       - name: Install dependencies
         run: |
@@ -46,7 +45,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-          cache: 'pip'
 
       - name: Install Python programs
         run: |
@@ -73,7 +71,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
 
       - name: Install markdown-link-check
         run: |


### PR DESCRIPTION
Remove npm and pip cache configurations from CI jobs that only install global packages and don't use project lock files. This fixes the errors:
- "Dependencies lock file is not found" for npm cache
- "No file matched" for pip cache requirements.txt/pyproject.toml

The CI jobs install global tools (markdownlint-cli, markdown-link-check, pyspelling) and don't need dependency caching.