### PR TITLE
docs: Add Source Academy SICP GitHub repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Agradecemos a todos os [contribuidores](https://github.com/ibrahimcesar/estrutur
 ## 🔗 Links Úteis
 
 - [SICP.js Original (inglês)](https://sourceacademy.org/sicpjs/index)
+- [Repositório Source Academy SICP (GitHub)](https://github.com/source-academy/sicp)
 - [SICP Original (Scheme)](https://mitpress.mit.edu/sites/default/files/sicp/index.html)
 - [Guia de Tradução](TRANSLATION.md)
 - [Como Contribuir](CONTRIBUTING.md)


### PR DESCRIPTION
Added reference to https://github.com/source-academy/sicp in the useful links section to provide direct access to the source repository.