### PR TITLE
Setup custom domain with GitHub Pages

### DIFF
--- a/.github/redirect-index.html
+++ b/.github/redirect-index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="refresh" content="0; url=/pt_BR/">
+    <title>SICP.js em Português - Redirecionando...</title>
+    <link rel="canonical" href="https://scipjs.com/pt_BR/">
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+                'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+                sans-serif;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            margin: 0;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+        }
+        .container {
+            text-align: center;
+        }
+        h1 {
+            font-size: 2.5rem;
+            margin-bottom: 1rem;
+        }
+        p {
+            font-size: 1.2rem;
+        }
+        a {
+            color: #ffd700;
+            text-decoration: none;
+            font-weight: bold;
+        }
+        a:hover {
+            text-decoration: underline;
+        }
+    </style>
+    <script>
+        // Immediate redirect
+        window.location.href = '/pt_BR/';
+    </script>
+</head>
+<body>
+    <div class="container">
+        <h1>🚀 SICP.js em Português</h1>
+        <p>Redirecionando para <a href="/pt_BR/">scipjs.com/pt_BR/</a>...</p>
+        <p><small>Se o redirecionamento não funcionar, <a href="/pt_BR/">clique aqui</a>.</small></p>
+    </div>
+</body>
+</html>

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Build website
         run: npm run build
 
+      - name: Setup redirect from root to /pt_BR/
+        run: |
+          cp .github/redirect-index.html build/index.html
+          echo "Redirect index.html created at root"
+          ls -la build/
+
       - name: Upload Build Artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -15,10 +15,10 @@ const config = {
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
-  url: 'https://ibrahimcesar.github.io',
+  url: 'https://scipjs.com',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/estrutura-e-interpretacao-de-programas-de-computador-javascript/',
+  baseUrl: '/pt_BR/',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+scipjs.com


### PR DESCRIPTION
- Update Docusaurus config to use scipjs.com domain with /pt_BR/ base URL
- Add CNAME file for GitHub Pages custom domain configuration
- Create redirect index.html to automatically redirect root to /pt_BR/
- Update deploy workflow to include redirect setup in build process

This setup allows the site to be accessed at scipjs.com/pt_BR/ while automatically redirecting visitors from the apex domain, leaving room for other language versions in the future.