### PR TITLE
fix: Corrige tag HTML não fechada em 1.3.4.md

### DIFF
--- a/docs/chapter-1/1.3.4.md
+++ b/docs/chapter-1/1.3.4.md
@@ -130,7 +130,7 @@ Nós começamos a seção 1.3 com a observação que funções compostas são um
 
 Como programadores, nós devemos ficar alerta a oportunidades para identificar abstrações subjacentes nos nossos programas e construir elas para generalizá-las afim que criar abstrações mais poderosas. Isso não quer dizer que você sempre deve escrever programas da maneira mais abstrata possível; programadores experientes sabem como escolher o nível de abstração apropriado para cada tarefa. Porém é importante ser capaz de pensar in termos dessas abstrações, então temos que estar preparados para aplicar elas em novos contextos. A importância de funções de ordem-maior é que elas permites que nos possamos representar essas abstrações explicitamente como elementos de nossa linguagem de programação, para que elas possam ser manipuladas como qualquer outro elemento computacional.
 
-No geral, linguagens de programação impõem restrições na maneira com o que os elementos computacionais podem ser manipulados. Elemento com menores restrições são ditos como tendo status de *primeira-classe*. Alguns dos "direitos e privilégios" dos elementos de primeira-classe são:<sup>[6](#footnote-link-6)
+No geral, linguagens de programação impõem restrições na maneira com o que os elementos computacionais podem ser manipulados. Elemento com menores restrições são ditos como tendo status de *primeira-classe*. Alguns dos "direitos e privilégios" dos elementos de primeira-classe são:<sup>[6](#footnote-link-6)</sup>
 
 - Eles podem ser chamados por nomes.
 - Eles podem ser passados como argumentos para funções.


### PR DESCRIPTION
Adiciona a tag de fechamento </sup> faltante na linha 133 que estava causando erro de build do Docusaurus. Este erro impedia que o site fosse gerado corretamente, resultando no site quebrado em produção.