### PR TITLE
fix: Corrige URL do site de scipjs.com para sicpjs.com

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -15,7 +15,7 @@ const config = {
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
-  url: 'https://scipjs.com',
+  url: 'https://sicpjs.com',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/pt_BR/',


### PR DESCRIPTION
O arquivo de configuração tinha um erro de digitação na URL do site. Estava 'https://scipjs.com' e deveria ser 'https://sicpjs.com'.