### PR TITLE
fix: Corrige estrutura de diretório do deployment e typo no redirect

### DIFF
--- a/.github/redirect-index.html
+++ b/.github/redirect-index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="refresh" content="0; url=/pt_BR/">
     <title>SICP.js em Português - Redirecionando...</title>
-    <link rel="canonical" href="https://scipjs.com/pt_BR/">
+    <link rel="canonical" href="https://sicpjs.com/pt_BR/">
     <style>
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
@@ -46,7 +46,7 @@
 <body>
     <div class="container">
         <h1>🚀 SICP.js em Português</h1>
-        <p>Redirecionando para <a href="/pt_BR/">scipjs.com/pt_BR/</a>...</p>
+        <p>Redirecionando para <a href="/pt_BR/">sicpjs.com/pt_BR/</a>...</p>
         <p><small>Se o redirecionamento não funcionar, <a href="/pt_BR/">clique aqui</a>.</small></p>
     </div>
 </body>

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,11 +39,20 @@ jobs:
       - name: Build website
         run: npm run build
 
-      - name: Setup redirect from root to /pt_BR/
+      - name: Setup pt_BR directory structure and redirect
         run: |
+          # Create pt_BR directory
+          mkdir -p build/pt_BR
+          # Move all files except CNAME to pt_BR
+          find build -maxdepth 1 -type f ! -name 'CNAME' -exec mv {} build/pt_BR/ \;
+          # Move all directories to pt_BR
+          find build -maxdepth 1 -mindepth 1 -type d ! -name 'pt_BR' -exec mv {} build/pt_BR/ \;
+          # Copy redirect index.html to root
           cp .github/redirect-index.html build/index.html
-          echo "Redirect index.html created at root"
+          echo "Directory structure created:"
           ls -la build/
+          echo "pt_BR contents:"
+          ls -la build/pt_BR/
 
       - name: Upload Build Artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
- Corrige typo 'scipjs' para 'sicpjs' no arquivo redirect-index.html
- Reestrutura o deployment para criar diretório pt_BR corretamente
- Move todos os arquivos buildados para build/pt_BR/ conforme esperado pelo baseUrl
- Mantém CNAME na raiz e adiciona redirect index.html na raiz
- Resolve erro 403 em https://sicpjs.com/pt_BR/