### PR TITLE
Migrate deprecated Docusaurus markdown config option

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -28,7 +28,13 @@ const config = {
   trailingSlash: false,
 
   onBrokenLinks: 'warn',
-  onBrokenMarkdownLinks: 'warn',
+
+  // Markdown configuration
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: 'warn',
+    },
+  },
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you


### PR DESCRIPTION
Move a opção `onBrokenMarkdownLinks` de configuração de nível superior para `markdown.hooks.onBrokenMarkdownLinks` conforme requisitos do Docusaurus v4. Isso resolve o aviso de deprecação e prepara o projeto para futuras atualizações.