### PR TITLE
Change interactive header color and text

### DIFF
--- a/src/components/CodePlayground.js
+++ b/src/components/CodePlayground.js
@@ -34,7 +34,7 @@ export default function CodePlayground({
         <div style={{
           padding: '0.5rem 1rem',
           background: 'var(--ifm-color-primary)',
-          color: 'white',
+          color: 'black',
           fontWeight: 'bold',
           borderRadius: '8px 8px 0 0'
         }}>

--- a/src/components/ExerciseBox.module.css
+++ b/src/components/ExerciseBox.module.css
@@ -31,7 +31,7 @@
 
 .solutionButton {
   background-color: var(--ifm-color-primary);
-  color: white;
+  color: black;
   border: none;
   padding: 0.5rem 1rem;
   border-radius: 4px;

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -6,13 +6,13 @@
 
 :root {
   /* Cores primárias */
-  --ifm-color-primary: #0066cc;
-  --ifm-color-primary-dark: #005bb8;
-  --ifm-color-primary-darker: #0052a3;
-  --ifm-color-primary-darkest: #00428f;
-  --ifm-color-primary-light: #0070e0;
-  --ifm-color-primary-lighter: #1a7ae6;
-  --ifm-color-primary-lightest: #3388eb;
+  --ifm-color-primary: #f7df1e;
+  --ifm-color-primary-dark: #ddc61b;
+  --ifm-color-primary-darker: #c9b318;
+  --ifm-color-primary-darkest: #a69414;
+  --ifm-color-primary-light: #f8e542;
+  --ifm-color-primary-lighter: #f9ea66;
+  --ifm-color-primary-lightest: #fbf08a;
 
   /* Código */
   --ifm-code-font-size: 95%;
@@ -31,13 +31,13 @@
 
 /* Modo escuro */
 [data-theme='dark'] {
-  --ifm-color-primary: #3388eb;
-  --ifm-color-primary-dark: #1a7ae6;
-  --ifm-color-primary-darker: #0070e0;
-  --ifm-color-primary-darkest: #0066cc;
-  --ifm-color-primary-light: #4d96ef;
-  --ifm-color-primary-lighter: #66a3f2;
-  --ifm-color-primary-lightest: #80b1f5;
+  --ifm-color-primary: #f7df1e;
+  --ifm-color-primary-dark: #ddc61b;
+  --ifm-color-primary-darker: #c9b318;
+  --ifm-color-primary-darkest: #a69414;
+  --ifm-color-primary-light: #f8e542;
+  --ifm-color-primary-lighter: #f9ea66;
+  --ifm-color-primary-lightest: #fbf08a;
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 
   --ifm-background-color: #1b1b1d;
@@ -111,6 +111,7 @@
 
 .markdown table th {
   background-color: var(--ifm-color-primary-lightest);
+  color: black;
   font-weight: 600;
 }
 
@@ -158,12 +159,12 @@
 .menu__link--active {
   font-weight: 600;
   background-color: var(--ifm-color-primary-lightest);
-  color: var(--ifm-color-primary-darkest);
+  color: black;
 }
 
 [data-theme='dark'] .menu__link--active {
   background-color: var(--ifm-color-primary-darkest);
-  color: var(--ifm-color-primary-lightest);
+  color: black;
 }
 
 /* Table of Contents */
@@ -190,7 +191,7 @@
   padding: 4rem 2rem;
   text-align: center;
   background: linear-gradient(135deg, var(--ifm-color-primary-lightest) 0%, var(--ifm-color-primary-light) 100%);
-  color: white;
+  color: black;
 }
 
 .hero__title {


### PR DESCRIPTION
Substitui o tema azul pelo amarelo #f7df1e (cor do JavaScript) em todos os componentes:
- Atualiza variáveis CSS primárias para tons de amarelo
- Muda cor do texto de branco para preto nos blocos interativos
- Aplica as mudanças em modo claro e escuro
- Garante melhor contraste e legibilidade com o novo tema

Componentes atualizados:
- CodePlayground: header com fundo amarelo e texto preto
- ExerciseBox: botão de solução com novo tema
- Hero section: gradiente amarelo com texto preto
- Menu ativo: destaque amarelo com texto preto
- Tabelas: cabeçalhos com fundo amarelo e texto preto