### PR TITLE
fix: Melhora contraste do menu de navegação

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -158,13 +158,13 @@
 
 .menu__link--active {
   font-weight: 600;
-  background-color: var(--ifm-color-primary-lightest);
-  color: black;
+  background-color: #e3f2fd;
+  color: #1565c0;
 }
 
 [data-theme='dark'] .menu__link--active {
-  background-color: var(--ifm-color-primary-darkest);
-  color: black;
+  background-color: #1a2332;
+  color: #90caf9;
 }
 
 /* Table of Contents */


### PR DESCRIPTION
Reverte as cores do menu ativo para tons de azul que oferecem melhor contraste e legibilidade, especialmente no tema claro. O amarelo JavaScript (#f7df1e) não fornecia contraste adequado no menu lateral.

Cores atualizadas:
- Tema claro: fundo azul claro (#e3f2fd) com texto azul escuro (#1565c0)
- Tema escuro: fundo azul escuro (#1a2332) com texto azul claro (#90caf9)